### PR TITLE
Fix logic for countries without mobile_begin_with values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -330,6 +330,14 @@ function get_iso3166_by_phone(phone) {
 
 		for (var j in iso3166_data[i].phone_number_lengths) {
 			if (phone.match(regex) && phone.length === iso3166_data[i].country_code.length + iso3166_data[i].phone_number_lengths[j]) {
+
+				// if the country doesn't have mobile prefixes (e.g. about 20 countries, like
+				// Argentina), then return the first match, as we can do no better
+
+				if ( 0 === iso3166_data[i].mobile_begin_with.length ) {
+					return iso3166_data[i];
+				}
+
 				// it match.. but may have more than one result.
 				// e.g. USA and Canada. need to check mobile_begin_with
 
@@ -350,6 +358,9 @@ function validate_phone_iso3166(phone, iso3166) {
 	phone = phone.replace(new RegExp('^' + iso3166.country_code), '');
 	for (var i in iso3166.phone_number_lengths) {
 		if (phone.length === iso3166.phone_number_lengths[i]) {
+			if ( 0 === iso3166.mobile_begin_with.length ) {
+				return true;
+			}
 			for (var j in iso3166.mobile_begin_with) {
 				if (phone.match(new RegExp('^' + iso3166.mobile_begin_with[j]))) {
 					return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "phone",
-	"version": "1.0.4",
+	"version": "1.0.4.1",
 	"description": "With a given country and phone number, validate and format the phone number to E.164 standard",
 	"main": "./lib/index",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "phone",
-	"version": "1.0.4.1",
+	"version": "1.0.4-1",
 	"description": "With a given country and phone number, validate and format the phone number to E.164 standard",
 	"main": "./lib/index",
 	"engines": {


### PR DESCRIPTION
Return the first match for the country code.  Fixes #1 

TESTING:

Argentina (allow 8 digit numbers.  no longer require leading 9 'cause mobile SMS doesn't support that)
+54 61712345

Croatia (allow 6 or 7 digit numbers after the prefix, not just 7)
+385 98 123456
+385 98 1234567

Denmark (allow prefix 28 (and others))
+45 28 12 34 56
