### PR TITLE
Allows numbers that start with 35 in Brazil

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ var iso3166_data = [
 	{alpha2: "BO", alpha3: "BOL", country_code: "591", country_name: "Bolivia", mobile_begin_with: ["7"], phone_number_lengths: [8]},
 	{alpha2: "BR", alpha3: "BRA", country_code: "55", country_name: "Brazil", mobile_begin_with: [
 		"119", "129", "139", "149", "159", "169", "179", "189", "199", "219", "229", "249", "279", "289", "31", "32",
-		"34", "38", "41", "43", "44", "45", "47", "48", "51", "53", "54", "55", "61", "62", "65", "67", "68", "69",
+		"34", "35", "38", "41", "43", "44", "45", "47", "48", "51", "53", "54", "55", "61", "62", "65", "67", "68", "69",
 		"71", "73", "75", "77", "79", "81", "82", "83", "84", "85", "86", "91", "92", "95", "96", "98"
 	], phone_number_lengths: [10, 11]},
 	{alpha2: "BB", alpha3: "BRB", country_code: "1", country_name: "Barbados", mobile_begin_with: [], phone_number_lengths: [7]},


### PR DESCRIPTION
Fixes an issue where Brazil numbers that began with "35" were rejected.
