### PR TITLE
Increase the phone number length validation for Austria. A user has r…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ var iso3166_data = [
 	//{alpha2: "TF", alpha3: "ATF", country_code: "", country_name: "French Southern Territories", mobile_begin_with: [], phone_number_lengths: []},
 	{alpha2: "AG", alpha3: "ATG", country_code: "1", country_name: "Antigua and Barbuda", mobile_begin_with: ["4", "7"], phone_number_lengths: [7]},
 	{alpha2: "AU", alpha3: "AUS", country_code: "61", country_name: "Australia", mobile_begin_with: ["4"], phone_number_lengths: [9]},
-	{alpha2: "AT", alpha3: "AUT", country_code: "43", country_name: "Austria", mobile_begin_with: ["6"], phone_number_lengths: [10]},
+	{alpha2: "AT", alpha3: "AUT", country_code: "43", country_name: "Austria", mobile_begin_with: ["6"], phone_number_lengths: [10, 11, 12, 13]},
 	{alpha2: "AZ", alpha3: "AZE", country_code: "994", country_name: "Azerbaijan", mobile_begin_with: ["4", "5", "6", "7"], phone_number_lengths: [9]},
 	{alpha2: "BI", alpha3: "BDI", country_code: "257", country_name: "Burundi", mobile_begin_with: ["7", "29"], phone_number_lengths: [8]},
 	{alpha2: "BE", alpha3: "BEL", country_code: "32", country_name: "Belgium", mobile_begin_with: ["4"], phone_number_lengths: [9]},


### PR DESCRIPTION
…eported that an 11-digit number isn't working, and Wikipedia suggests that numbers can be as long as 13 digits in Austria:

 https://en.wikipedia.org/wiki/Telephone_numbers_in_Europe
