### PR TITLE
Add a seven-digit valid phone number length for Estonia.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,7 +108,7 @@ var iso3166_data = [
 	{alpha2: "ER", alpha3: "ERI", country_code: "291", country_name: "Eritrea", mobile_begin_with: ["1", "7", "8"], phone_number_lengths: [7]},
 	//{alpha2: "EH", alpha3: "ESH", country_code: "212", country_name: "Western Sahara", mobile_begin_with: [], phone_number_lengths: []},
 	{alpha2: "ES", alpha3: "ESP", country_code: "34", country_name: "Spain", mobile_begin_with: ["6", "7"], phone_number_lengths: [9]},
-	{alpha2: "EE", alpha3: "EST", country_code: "372", country_name: "Estonia", mobile_begin_with: ["5"], phone_number_lengths: [8]},
+	{alpha2: "EE", alpha3: "EST", country_code: "372", country_name: "Estonia", mobile_begin_with: ["5"], phone_number_lengths: [7, 8]},
 	{alpha2: "ET", alpha3: "ETH", country_code: "251", country_name: "Ethiopia", mobile_begin_with: ["9"], phone_number_lengths: [9]},
 	{alpha2: "FI", alpha3: "FIN", country_code: "358", country_name: "Finland", mobile_begin_with: ["4", "5"], phone_number_lengths: [9]},
 	{alpha2: "FJ", alpha3: "FJI", country_code: "679", country_name: "Fiji", mobile_begin_with: ["7", "9"], phone_number_lengths: [7]},


### PR DESCRIPTION
A user reported that their 7-digit number is not working, and Wikipedia
states that valid mobile numbers can be 7 or 8 digits long in Estonia:

https://en.wikipedia.org/wiki/Telephone_numbers_in_Europe
