### PR TITLE
Allow "8" as a valid first digit in mobile phone numbers. Per [Wikipe…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,7 +111,7 @@ var iso3166_data = [
 	{alpha2: "EE", alpha3: "EST", country_code: "372", country_name: "Estonia", mobile_begin_with: ["5"], phone_number_lengths: [7, 8]},
 	{alpha2: "ET", alpha3: "ETH", country_code: "251", country_name: "Ethiopia", mobile_begin_with: ["9"], phone_number_lengths: [9]},
 	{alpha2: "FI", alpha3: "FIN", country_code: "358", country_name: "Finland", mobile_begin_with: ["4", "5"], phone_number_lengths: [9]},
-	{alpha2: "FJ", alpha3: "FJI", country_code: "679", country_name: "Fiji", mobile_begin_with: ["7", "9"], phone_number_lengths: [7]},
+	{alpha2: "FJ", alpha3: "FJI", country_code: "679", country_name: "Fiji", mobile_begin_with: ["7", "8", "9"], phone_number_lengths: [7]},
 	{alpha2: "FK", alpha3: "FLK", country_code: "500", country_name: "Falkland Islands (Malvinas)", mobile_begin_with: ["5", "6"], phone_number_lengths: [5]},
 	{alpha2: "FR", alpha3: "FRA", country_code: "33", country_name: "France", mobile_begin_with: ["6", "7"], phone_number_lengths: [9]},
 	{alpha2: "FO", alpha3: "FRO", country_code: "298", country_name: "Faroe Islands", mobile_begin_with: [], phone_number_lengths: [6]},


### PR DESCRIPTION
…dia](https://en.wikipedia.org/wiki/Telephone_numbers_in_Fiji), this is a valid starting number for Inkk Mobile.
