### PR TITLE
Allow eight-digit phone number length for Mauritius.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -193,7 +193,7 @@ var iso3166_data = [
 	{alpha2: "MR", alpha3: "MRT", country_code: "222", country_name: "Mauritania", mobile_begin_with: [], phone_number_lengths: [8]},
 	{alpha2: "MS", alpha3: "MSR", country_code: "1", country_name: "Montserrat", mobile_begin_with: [], phone_number_lengths: [7]},
 	{alpha2: "MQ", alpha3: "MTQ", country_code: "596", country_name: "Martinique", mobile_begin_with: ["696"], phone_number_lengths: [9]},
-	{alpha2: "MU", alpha3: "MUS", country_code: "230", country_name: "Mauritius", mobile_begin_with: [], phone_number_lengths: [7]},
+	{alpha2: "MU", alpha3: "MUS", country_code: "230", country_name: "Mauritius", mobile_begin_with: ["5", "87"], phone_number_lengths: [7, 8]},
 	{alpha2: "MW", alpha3: "MWI", country_code: "265", country_name: "Malawi", mobile_begin_with: ["77", "88", "99"], phone_number_lengths: [9]},
 	{alpha2: "MY", alpha3: "MYS", country_code: "60", country_name: "Malaysia", mobile_begin_with: ["1"], phone_number_lengths: [9, 10]},
 	{alpha2: "YT", alpha3: "MYT", country_code: "269", country_name: "Mayotte", mobile_begin_with: ["639"], phone_number_lengths: [9]},


### PR DESCRIPTION
A user reported that their 8-digit mobile phone number was not working. Wikipedia states that valid numbers in Mauritius start with the number 5 and have 8 digits:

https://en.wikipedia.org/wiki/Telephone_numbers_in_Mauritius
