### PR TITLE
Update the area code list of Brazil according to

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,9 +61,15 @@ var iso3166_data = [
 	{alpha2: "BM", alpha3: "BMU", country_code: "1", country_name: "Bermuda", mobile_begin_with: ["3", "5", "7"], phone_number_lengths: [7]},
 	{alpha2: "BO", alpha3: "BOL", country_code: "591", country_name: "Bolivia", mobile_begin_with: ["7"], phone_number_lengths: [8]},
 	{alpha2: "BR", alpha3: "BRA", country_code: "55", country_name: "Brazil", mobile_begin_with: [
-		"119", "129", "139", "149", "159", "169", "179", "189", "199", "219", "229", "249", "279", "289", "31", "32",
-		"33", "34", "35", "37", "38", "41", "43", "44", "45", "47", "48", "51", "53", "54", "55", "61", "62", "65", "67", "68", "69",
-		"71", "73", "74", "75", "77", "79", "81", "82", "83", "84", "85", "86", "91", "92", "95", "96", "98"
+		"119", "129", "139", "149", "159", "169", "179", "189", "199",  // Sao Paulo
+		"219", "229", "249", "279", "289",                              // Rio de Janeiro and Espirito Santo
+		"31", "32", "33", "34", "35", "37", "38",                       // Minas Gerais
+		"41", "42", "43", "44", "45", "46", "47", "48", "49",           // Parana and Santa Catarina
+		"51", "53", "54", "55",                                         // Rio Grande do Sul
+		"61", "62", "63", "64", "65", "66", "67", "68", "69",           // Central-West Region and states of Tocantins, Acre and Rondonia
+		"71", "73", "74", "75", "77", "79",                             // Bahia and Sergipe
+		"81", "82", "83", "84", "85", "86", "87", "88", "89",           // Northeast Region
+		"91", "92", "93", "94", "95", "96", "97", "98", "99",           // North Region and the state of Maranhao
 	], phone_number_lengths: [10, 11]},
 	{alpha2: "BB", alpha3: "BRB", country_code: "1", country_name: "Barbados", mobile_begin_with: [], phone_number_lengths: [7]},
 	{alpha2: "BN", alpha3: "BRN", country_code: "673", country_name: "Brunei Darussalam", mobile_begin_with: ["7", "8"], phone_number_lengths: [7]},


### PR DESCRIPTION
## Summary

Update the list of area codes of Brazil according to https://en.wikipedia.org/wiki/List_of_dialling_codes_in_Brazil.
## Details
- The following area codes are added: 42, 46, 49, 63, 64, 66, 66, 87, 88, 89, 93, 94, 97, 99.
- Format the area codes and sort them according to numerical order and the states they represents to ease comparing and tracking.
- According to [this thread](http://www.howtocallabroad.com/forums/topic/brazil-telephone-numbering-changes), Brazil's National Telecom Agency are incrementally adding a **9** to all mobile phone numbers after the area code. As I couldn't find a complete nor a official document stating the whole progress, I decided to play safe and thus didn't update any 9-prefix in this commit.
