### PR TITLE
Fix Myanmar mobile phone numbers length.

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1003,6 +1003,35 @@ describe('Testing CHN Phone Quick Test', () => {
         });
     });
 
+});
 
-
+describe( 'Testing MMR Phone', () => {
+	describe('Test for 8 digits mobile numbers ', () => {
+		const number = '+95 9 55 00000';
+		const result = ['+9595500000', 'MMR'];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
+	describe('Test for 9 digits mobile numbers ', () => {
+		const number = '+95 9 30 000 000';
+		const result = ['+95930000000', 'MMR'];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
+	describe('Test 10 digits mobile numbers', () => {
+		const number = '+95 9 426 00 0000';
+		const result = ['+959426000000', 'MMR'];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
+	describe('Test land lines', () => {
+		const number = '+95 1 1234567'; //Landlines
+		const result = [];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
 });

--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -1120,7 +1120,7 @@ module.exports = [
 		country_code: '95',
 		country_name: 'Myanmar',
 		mobile_begin_with: ['9'],
-		phone_number_lengths: [8]
+		phone_number_lengths: [8, 9, 10]
 	},
 	{
 		alpha2: 'ME',


### PR DESCRIPTION
Can be either 8,9,10 digits long, including 9 prefix.
Source: https://www.itu.int/oth/T0202000092/en

Upstream PR: https://github.com/AfterShip/phone/pull/123